### PR TITLE
Feature: Add revenue calculation and who has most revenue

### DIFF
--- a/app/controllers/api/v1/merchants/revenue_controller.rb
+++ b/app/controllers/api/v1/merchants/revenue_controller.rb
@@ -1,0 +1,5 @@
+class Api::V1::Merchants::RevenueController < ApplicationController
+  def index
+    render json: MerchantSerializer.new(Merchant.where())
+  end
+end

--- a/app/controllers/api/v1/merchants/revenue_controller.rb
+++ b/app/controllers/api/v1/merchants/revenue_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::Merchants::RevenueController < ApplicationController
   def index
-    render json: MerchantSerializer.new(Merchant.where())
+    render json: MerchantSerializer.new(Merchant.most_revenue(params[:quantity]))
   end
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -6,4 +6,5 @@ class Invoice < ApplicationRecord
 
   has_many :invoice_items
   has_many :items, through: :invoice_items
+  has_many :transactions
 end

--- a/app/models/invoice_item.rb
+++ b/app/models/invoice_item.rb
@@ -1,4 +1,6 @@
 class InvoiceItem < ApplicationRecord
   belongs_to :item
   belongs_to :invoice
+
+  has_many :transactions, through: :invoice
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -2,6 +2,9 @@ class Merchant < ApplicationRecord
   validates_presence_of :name
 
   has_many :items
+  has_many :invoices
+  has_many :transactions, through: :invoices
+  has_many :invoice_items, through: :invoices
 
   def self.search_for(search_params)
     where(search_params.keys.map { |param| "#{param} ILIKE '%#{search_params[param]}%'" }
@@ -15,4 +18,23 @@ class Merchant < ApplicationRecord
   def self.get_all_merchants_by(search_params)
     search_for(search_params)
   end
+
+  def self.most_revenue(quantity)
+    all.sort_by do |merchant|
+      merchant.revenue
+    end.reverse[0..quantity.to_i-1]
+  end
+
+  def revenue
+    transactions
+      .where(result: 'success')
+      .joins(:invoice_items)
+      .sum('invoice_items.quantity * invoice_items.unit_price')
+  end
 end
+
+# Merchant.items.joins(:transactions)
+#               .where(transactions: { result: :success})
+#               .select("merchants.*, sum(invoice_items.quantity * invoice_items.unit_price) as revenue")
+#               .group(:id).order('revenue', :DESC)
+#               .limit(params[:quantity])

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -1,4 +1,5 @@
 class Transaction < ApplicationRecord
   validates_presence_of :credit_card_number, :result
   belongs_to :invoice
+  has_many :invoice_items, through: :invoice
 end

--- a/app/serializers/merchant_serializer.rb
+++ b/app/serializers/merchant_serializer.rb
@@ -1,4 +1,4 @@
 class MerchantSerializer
   include FastJsonapi::ObjectSerializer
-  attributes :name
+  attributes :name, :revenue
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
         get '/:id/items', to: 'items#index'
         get '/find', to: 'search#show'
         get '/find_all', to: 'search#index'
+        get '/most_revenue', to: 'revenue#index'
       end
 
       namespace :items do

--- a/spec/requests/api/v1/merchant/merchant_most_revenue_spec.rb
+++ b/spec/requests/api/v1/merchant/merchant_most_revenue_spec.rb
@@ -2,15 +2,32 @@ require 'rails_helper'
 
 RSpec.describe 'Merchant Most Revenue' do
   it 'can get merchants with the most revenue' do
-    merchant_1 = create(:merchant)
-    merchant_2 = create(:merchant)
-    merchant_3 = create(:merchant)
-    merchant_4 = create(:merchant)
+    merchant_1 = create(:merchant, name: 'First Merchant')
+    merchant_2 = create(:merchant, name: 'Second Merchant')
+    merchant_3 = create(:merchant, name: 'Third Merchant')
+    merchant_4 = create(:merchant, name: 'Fourth Merchant')
+
+    invoice_items_1 = create_list(:invoice_item, 3, quantity: 1, unit_price: 50)
+    invoice_items_2 = create_list(:invoice_item, 2, quantity: 10, unit_price: 10)
+
+    invoice_items_1.each do |invoice_item|
+      invoice_item.invoice.update(merchant_id: merchant_1.id)
+      create(:transaction, invoice: invoice_item.invoice, result: 'success')
+    end
+
+    invoice_items_2.each do |invoice_item|
+      invoice_item.invoice.update(merchant_id: merchant_2.id)
+      create(:transaction, invoice: invoice_item.invoice, result: 'success')
+    end
 
     get '/api/v1/merchants/most_revenue?quantity=2'
 
     expect(response).to be_successful
 
-    require 'pry'; binding.pry
+    merchants_json = JSON.parse(response.body, symbolize_names: true)
+
+    expect(merchants_json[:data].count).to eq(2)
+    expect(merchants_json[:data].first[:attributes][:name]).to eq('Second Merchant')
+    expect(merchants_json[:data].last[:attributes][:name]).to eq('First Merchant')
   end
 end

--- a/spec/requests/api/v1/merchant/merchant_most_revenue_spec.rb
+++ b/spec/requests/api/v1/merchant/merchant_most_revenue_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe 'Merchant Most Revenue' do
+  it 'can get merchants with the most revenue' do
+    merchant_1 = create(:merchant)
+    merchant_2 = create(:merchant)
+    merchant_3 = create(:merchant)
+    merchant_4 = create(:merchant)
+
+    get '/api/v1/merchants/most_revenue?quantity=2'
+
+    expect(response).to be_successful
+
+    require 'pry'; binding.pry
+  end
+end


### PR DESCRIPTION
* Added extra relationships to cut active record calls to a minimum
* Added `most_revenue` class method to the merchant controller.
  - Orders the merchants by revenue
  - Uses `params[:quantity]` to limit how many merchants are shown in the list, which is passed down from the controller/route
* Added `revenue` instance method to  merchant
  - Uses new relationships to access transactions on a merchant directly.
  - Calculates the revenue using the `sum` active record query in conjunction with a SQL call within there to accurately represent each revenue, per merchant.
* Added revenue to each merchant, individually
  - Added a new attribute to each merchant through the serializer
  - Utilizes the `revenue` method referenced earlier.

* Minor cleanup and ensuring of RESTful routing